### PR TITLE
fix(resume): 修复实时监听重名与单列模板求职意向缺字段

### DIFF
--- a/src/components/resume/runtime/renderers/BasicsRenderer.tsx
+++ b/src/components/resume/runtime/renderers/BasicsRenderer.tsx
@@ -25,6 +25,8 @@ export default function BasicsRenderer() {
   ].filter(Boolean)
   const jobIntentFields = [
     job_intent.jobIntent,
+    job_intent.intentionalCity,
+    job_intent.expectedSalary ? `${job_intent.expectedSalary}K` : '',
     job_intent.dateEntry !== '不填' ? job_intent.dateEntry : '',
   ].filter(Boolean)
   const mergedJobIntent = layout.skeleton === 'single-column' && getVisibility('job_intent')

--- a/src/lib/supabase/resume/config.ts
+++ b/src/lib/supabase/resume/config.ts
@@ -27,7 +27,7 @@ export async function subscribeToResumeConfigUpdates(
     throw new Error('用户未登陆')
 
   const channel = supabase
-    .channel(`resume_config_changes`)
+    .channel(`resume_config_changes:${user.id}:${crypto.randomUUID()}`)
     .on(
       'postgres_changes',
       { event: '*', schema: 'public', table: 'resume_config', filter: `user_id=eq.${user.id}` },


### PR DESCRIPTION
- 为 subscribeToResumeConfigUpdates 的 Supabase channel 名拼入 user.id 与 uuid，避免列表页与编辑器共用同一 topic 触发 "cannot add postgres_changes callbacks after subscribe()" 错误
- BasicsRenderer 单列布局的 jobIntentFields 补齐 intentionalCity 与 expectedSalary，与 JobIntentRenderer 保持一致，修复单列模板头部漏显意向城市与期望薪资的问题
